### PR TITLE
fix: Downbeat_idx error in preprocess.py

### DIFF
--- a/preprocess/preprocess.py
+++ b/preprocess/preprocess.py
@@ -277,9 +277,9 @@ def align_midi_beats(piece_dir):
   print(len(vocal_notes), len(bridge_notes), len(piano_notes))
   
   # recalculate bpm
-  if downbeat_idx not in range(1, 5):
-    print('error: downbeat_idx = {}'.format(downbeat_idx))
-    exit(1)
+  # change index 0 to 4
+  if downbeat_idx == 0:
+    downbeat_idx = 4
   
   first_beat_tick = (4-downbeat_idx) * DEFAULT_TICKS_PER_BEAT
   first_bpm = np.round( (60./(midi_beat_times[1]-midi_beat_times[0])), 2 )


### PR DESCRIPTION
# Downbeat_idx error in preprocess.py
In `./preprocess/preprocess.py'

The return value of function `find_downbeat_idx_audio`
```
def find_downbeat_idx_audio(audio_dbt):
  for st_idx in range(4):
    if audio_dbt[ st_idx ] == 1.:
      return st_idx
```
can only be in range [0,3]

However, the following code only allows downbeat_idx to fall in [1,4], which may be a mistake.
```
if downbeat_idx not in range(1, 5):
    print('error: downbeat_idx = {}'.format(downbeat_idx))
    exit(1)
```
So I change downbeat_idx from 0 to 4.
